### PR TITLE
Invalidate category flat index

### DIFF
--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -2,7 +2,10 @@
 
 namespace Mestrona\CategoryRedirect\Setup;
 
+use Magento\Catalog\Model\Indexer\Category\Flat\State;
+use Magento\Eav\Setup\EavSetup;
 use Magento\Eav\Setup\EavSetupFactory;
+use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Framework\Setup\InstallDataInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
@@ -17,13 +20,29 @@ class InstallData implements InstallDataInterface
     private $eavSetupFactory;
 
     /**
-     * Init
+     * Flat category indexer state
      *
-     * @param EavSetupFactory $eavSetupFactory
+     * @var State
      */
-    public function __construct(EavSetupFactory $eavSetupFactory)
+    protected $flatState;
+
+    /**
+     * Indexer registry
+     *
+     * @var IndexerRegistry
+     */
+    protected $indexerRegistry;
+
+    /**
+     * @param EavSetupFactory $eavSetupFactory
+     * @param State $flatState
+     * @param IndexerRegistry $indexerRegistry
+     */
+    public function __construct(EavSetupFactory $eavSetupFactory, State $flatState, IndexerRegistry $indexerRegistry)
     {
         $this->eavSetupFactory = $eavSetupFactory;
+        $this->flatState = $flatState;
+        $this->indexerRegistry = $indexerRegistry;
     }
 
     /**
@@ -56,5 +75,9 @@ class InstallData implements InstallDataInterface
                 'visible_on_front' => true,
             ]
         );
+
+        if ($this->flatState->isFlatEnabled()) {
+            $this->indexerRegistry->get(State::INDEXER_ID)->invalidate();
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "mestrona/magento-module-categoryredirect",
     "description": "Magento 2 Module to simply customize the menu with additional URLs: Create a category, enter the redirect, done.",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0",
-        "magento/module-catalog": "^100.0.0|^101.0.0|^102.0.0"
+        "php": "^7.0",
+        "magento/module-catalog": "^100.0.0 || ^101.0.0 || ^102.0.0 || ^103.0"
     },
     "type": "magento2-module",
     "license": [


### PR DESCRIPTION
Hi!

When flat category index is enabled and we install the module, this results in fatal errors on landing page: https://prnt.sc/pf6m0m

To remedy this, we have to manually run `bin/magento indexer:reindex catalog_category_flat` once on DEVs and production right after publish (or after client reports site is down).

Solution - when adding category or product attributes, invalidate flat indexes.

Please have a look :)